### PR TITLE
Update class to lesson in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 ### TuitiONE allows customer service officers to get their student management tasks done quickly and easily.
 <br>
 
- Example usages:
-   * Add and remove students from the tuition center
-   * Track students’ details
-   * [Coming soon] Update students’ details
-   * Enroll students from classes
-   * Unenroll students from classes
- 
+Example usages:
+* Add and remove students from the tuition center
+* Track students’ details
+* Enroll students for lessons
+* Unenroll students from lessons
+* [Coming soon] Update students’ details
+
 For the detailed documentation of this project, see the **[Address Book Product Website](https://ay2122s1-cs2103t-f13-4.github.io/tp/)**.
 
 This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -129,31 +129,31 @@ Examples:
 * `list` followed by `delete 2` deletes the student indexed 2 in the TuitiONE.
 * `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
 
-### Unenrolling a student from class: `enroll`
+### Unenrolling a student from lesson: `enroll`
 
-Enroll a student from a given TuitiONE class.
+Enroll a student from a given TuitiONE lesson.
 
-Format: `enroll INDEX c/CLASS`
+Format: `enroll INDEX l/LESSON`
 
-* Enroll the student identified by `INDEX` from the specific `class`.
+* Enroll the student identified by `INDEX` from the specific `lesson`.
 * The index refers to the index number shown in the displayed student list.
 * The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
-* `enroll 1 c/cs2103T` will unenroll the student indexed 1 from class "cs2103T"
+* `enroll 1 l/cs2103T` will unenroll the student indexed 1 from lesson "cs2103T"
 
-### Unenrolling a student from class: `unenroll`
+### Unenrolling a student from lesson: `unenroll`
 
-Unenroll a student from a given TuitiONE class.
+Unenroll a student from a given TuitiONE lesson.
 
-Format: `unenroll INDEX c/CLASS`
+Format: `unenroll INDEX l/LESSON`
 
-* Unenroll the student identified by `INDEX` from the specific `class`.
+* Unenroll the student identified by `INDEX` from the specific `lesson`.
 * The index refers to the index number shown in the displayed student list.
 * The index **must be a positive integer** 1, 2, 3, …​
 
 Examples:
-* `unenroll 1 c/cs2103T` will unenroll the student indexed 1 from class "cs2103T"
+* `unenroll 1 l/cs2103T` will unenroll the student indexed 1 from lesson "cs2103T"
 
 ### Clearing all entries : `clear`
 
@@ -188,8 +188,8 @@ Action | Format, Examples
 **Add** | `add n/NAME p/PARENT_PHONE_NUMBER a/ADDRESS e/EDUCATION_LEVEL [t/TAG]…​` <br> e.g., `add n/John Doe p/98765432 a/John street, block 123, #01-01 e/P2`
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Enroll** | `enroll INDEX c/CLASS`<br> e.g. `enroll 1 c/cs2103T`
-**Unenroll** | `unenroll 1 c/cs2103T`<br> e.g. `unenroll 1 c/cs2103T`
+**Enroll** | `enroll INDEX l/LESSON`<br> e.g. `enroll 1 l/cs2103T`
+**Unenroll** | `unenroll 1 l/cs2103T`<br> e.g. `unenroll 1 l/cs2103T`
 **Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **List** | `list`
 **Help** | `help`


### PR DESCRIPTION
Changes made:
- Change `class` to `lesson` in documentation
- Change syntax for `enroll` and `unenroll` commands
  - From `enroll INDEX c/CLASS` to `enroll INDEX l/LESSON`

TODO:
- Update user stories to match as well