### PR TITLE
Modify Look Up (FindCommand) function

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,7 +7,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The student index provided is invalid";
+    public static final String MESSAGE_PLURAL_STUDENT_LISTED_OVERVIEW = "%1$d students found!";
+    public static final String MESSAGE_SINGULAR_STUDENT_LISTED_OVERVIEW = "%1$d student found!";
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -29,8 +29,10 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+        String output = model.getFilteredPersonList().size() == 0 || model.getFilteredPersonList().size() == 1
+                ? String.format(Messages.MESSAGE_SINGULAR_STUDENT_LISTED_OVERVIEW, model.getFilteredPersonList().size())
+                : String.format(Messages.MESSAGE_PLURAL_STUDENT_LISTED_OVERVIEW, model.getFilteredPersonList().size());
+        return new CommandResult(output);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -3,7 +3,8 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.commons.core.Messages.MESSAGE_SINGULAR_STUDENT_LISTED_OVERVIEW;
+import static seedu.address.commons.core.Messages.MESSAGE_PLURAL_STUDENT_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
@@ -56,7 +57,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MESSAGE_SINGULAR_STUDENT_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -65,8 +66,18 @@ public class FindCommandTest {
     }
 
     @Test
+    public void execute_oneKeyword_onePersonFound() {
+        String expectedMessage = String.format(MESSAGE_SINGULAR_STUDENT_LISTED_OVERVIEW, 1);
+        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL), model.getFilteredPersonList());
+    }
+
+    @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        String expectedMessage = String.format(MESSAGE_PLURAL_STUDENT_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);


### PR DESCRIPTION
1. Modify `find` command

- String "person" is changed to "student"
- Add in singular and plural form of system prompt to the user

2. Implement test case for the above edits on features

---

Example:

1. No student found

![image](https://user-images.githubusercontent.com/62177572/136074821-a0060247-33b6-4450-a780-b3eb811b4bdd.png)

2. 1 student found

![image](https://user-images.githubusercontent.com/62177572/136074754-e145f15d-5159-41b0-85ab-672de0d8c2a6.png)

3. 2 student found

![image](https://user-images.githubusercontent.com/62177572/136074876-8f0ccdc6-7069-4298-a1a9-d63504bf6884.png)
