### PR TITLE
Fix unable to edit Students that are enrolled by fields other than Name and Grade

### DIFF
--- a/src/main/java/seedu/tuitione/model/lesson/Lesson.java
+++ b/src/main/java/seedu/tuitione/model/lesson/Lesson.java
@@ -189,13 +189,13 @@ public class Lesson {
     public void updateStudent(Student oldStudent, Student newStudent) {
         requireAllNonNull(oldStudent, newStudent);
         checkArgument(isAbleToUnenroll(oldStudent), String.format(STUDENT_NOT_ENROLLED, oldStudent.getName(), this));
-        checkArgument(isAbleToEnroll(newStudent), String.format(ENROLLMENT_MESSAGE_CONSTRAINT, oldStudent.getName()));
 
-        for (int idx = 0; idx < students.size(); idx++) {
-            if (students.get(idx).isSameStudent(oldStudent)) {
-                students.set(idx, newStudent);
-                newStudent.addLesson(this);
+        for (Student student : students) {
+            if (student.isSameStudent(oldStudent)) {
                 removeStudent(oldStudent);
+                checkArgument(isAbleToEnroll(newStudent),
+                        String.format(ENROLLMENT_MESSAGE_CONSTRAINT, newStudent.getName()));
+                addStudent(newStudent);
                 return;
             }
         }


### PR DESCRIPTION
### Explanation:
- The pervious set up checks if the old student can be unenrolled (which works as intended)
- The part where it checks where if the new student can be enrolled in is where the bug appears
  - If the old and new student have the same name, then it will clash, preventing the update
 
### Fix:
- Only do the latter check once we have unenrolled the old student